### PR TITLE
server: fix full-vocab probability serialization and normalization

### DIFF
--- a/examples/server/server-common.cpp
+++ b/examples/server/server-common.cpp
@@ -1127,8 +1127,6 @@ token_probabilities get_token_probabilities(llama_context* ctx, int idx, llama_t
             sampled_token_found = true;
         }
     }
-    for (int i = n_sorted; i < n_vocab; ++i) cum_sum += expf(sorted[i].first - max_l);
-
     float inv_cum_sum = 1 / cum_sum;
     for (int i = 0; i < n_sorted; ++i) cur[i].p *= inv_cum_sum;
     sampled_token_p *= inv_cum_sum;

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -445,7 +445,7 @@ auto res_err = [](httplib::Response& res, json error_data) {
 };
 
 auto res_ok = [](httplib::Response& res, const json& data) {
-    res.set_content(data.dump(), "application/json; charset=utf-8");
+    res.set_content(safe_json_to_str(data), "application/json; charset=utf-8");
     res.status = 200;
 };
 


### PR DESCRIPTION
## Summary

Fix two independent bugs in the server probability-response path with a minimal patch:

1. Non-streaming successful responses used `json::dump()` directly. Full-vocabulary probability output can contain token pieces that are not valid standalone UTF-8, causing `nlohmann::json` to throw and `/completion` to return HTTP 500.
2. `get_token_probabilities()` accumulated all vocabulary probabilities, then accumulated the non-top-N tail a second time. This under-normalized probabilities whenever `n_probs < n_vocab`.

## Changes

- Route successful HTTP JSON through the existing `safe_json_to_str()` helper, matching the current llama.cpp server pattern for safe JSON serialization.
- Remove the duplicate tail accumulation in `get_token_probabilities()`.

No API fields or response schema are changed.

## Reproduction / validation

Tested with `PXA-Fusion4-35B-PXQ4.gguf` (`n_vocab = 248320`) on the same request before and after the patch.

Before:
- `n_probs=248320` -> HTTP 500: `incomplete UTF-8 string; last byte: 0xE2`
- `n_probs=32` top-32 probability mass: `0.7035611437`

After:
- `n_probs=248320` -> HTTP 200 with `248320 / 248320` entries
- server remains healthy after the response
- `n_probs=32` uses the same top-token ordering as before
- patched top-32 mass: `0.8258273085`
- patched top-32 probabilities exactly match the corresponding entries in the patched full-vocabulary response in the regression run

The full-vocabulary sum is `1.0008236729`; this residual is the existing float softmax accumulation behavior and is intentionally not changed in this minimal fix. Current llama.cpp likewise performs this probability softmax using float accumulation.

## Why this shape

An earlier version added a custom UTF-8 validator/byte formatter. That was unnecessary: the repository already has `safe_json_to_str()`, and current llama.cpp uses the same safe-serialization pattern. The PR was reduced to the smallest behaviorally sufficient change.
